### PR TITLE
fix(SButton): 修复按钮中文换行

### DIFF
--- a/src/button/button.slint
+++ b/src/button/button.slint
@@ -155,6 +155,7 @@ export component Button inherits SCard {
         font-weight: root.font-weight;
         font-italic: root.font-italic;
         letter-spacing: root.letter-spacing;
+        wrap: no-wrap;
       }
     }
   }


### PR DESCRIPTION
修复前：
![](https://files.catbox.moe/6u4gt5.png)
修复后：
![](https://files.catbox.moe/wnh22h.png)

pr格式有问题，可以说说。