### PR TITLE
fix(SMenu): 修复了SMenu中STip中文会换行

### DIFF
--- a/src/menu/menu.slint
+++ b/src/menu/menu.slint
@@ -103,6 +103,7 @@ export component Menu inherits SCard {
         theme: root.theme;
         position: Right;
         is-show : menu-item.has-hover;
+        wrap: no-wrap;
         menu-item:=MenuItem{
           active: item.id == root.active;
           height: icon-box-size;


### PR DESCRIPTION
修复前:
![1703650709897-2023-12-27-12:18:30.png](https://fastly.jsdelivr.net/gh/ZhengLongBing/images@main/pictures/1703650709897-2023-12-27-12:18:30.png)

修复后:
![1703650697983-2023-12-27-12:18:18.png](https://fastly.jsdelivr.net/gh/ZhengLongBing/images@main/pictures/1703650697983-2023-12-27-12:18:18.png)